### PR TITLE
Update docs to run intro with Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ## 사용법
 ```bash
-rye run intro --details
+python -m cli_intro.app --details
 ```
 `--details` 옵션을 주면 연락처 정보가 함께 출력됩니다.
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -3,5 +3,5 @@
 아래와 같이 실행하여 개발자 정보를 확인할 수 있습니다.
 
 ```bash
-rye run intro --details
+python -m cli_intro.app --details
 ```


### PR DESCRIPTION
## Summary
- update README usage instructions to use `python -m cli_intro.app`
- update docs/USAGE to mirror new Python-based invocation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rich')*

------
https://chatgpt.com/codex/tasks/task_e_6885fb030ec08327bc85913620e0b854