### PR TITLE
Load profile from .env

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@
    rye sync
    ```
 
-환경 변수는 `config/.env.example` 파일을 참고하여 설정합니다.
+프로그램은 실행 시 `config/.env` 파일을 자동으로 로드합니다.
+필요한 값은 `config/.env.example` 파일을 참고하여 작성하세요.
 
 ## 사용법
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "click",
     "rich",
     "pyfiglet",
+    "python-dotenv",
 ]
 packages = [{ include = "cli_intro", from = "src" }]
 

--- a/src/cli_intro/services/profile_service.py
+++ b/src/cli_intro/services/profile_service.py
@@ -1,13 +1,19 @@
 """프로필 정보를 환경 변수에서 로드하는 서비스."""
 
 import os
+from pathlib import Path
 from typing import Optional
+
+from dotenv import load_dotenv
 
 from ..models.profile import Profile
 
 
 def load_profile() -> Optional[Profile]:
     """환경 변수에서 프로필 정보를 읽어 :class:`Profile` 객체를 반환합니다."""
+    env_path = Path(__file__).resolve().parents[2].parent / "config" / ".env"
+    load_dotenv(env_path)
+
     name = os.getenv("DEV_NAME")
     email = os.getenv("DEV_EMAIL")
     title = os.getenv("DEV_TITLE")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -29,3 +29,24 @@ def test_main_missing_profile(monkeypatch):
     result = runner.invoke(main)
     assert result.exit_code != 0
     assert "프로필 정보" in result.output
+
+
+def test_main_load_from_env_file(monkeypatch):
+    env_path = pathlib.Path(__file__).resolve().parents[1] / "config" / ".env"
+    env_content = "\n".join([
+        "DEV_NAME=파일",
+        "DEV_EMAIL=file@example.com",
+        "DEV_TITLE=파일 개발자",
+    ])
+    env_path.write_text(env_content)
+    try:
+        monkeypatch.delenv("DEV_NAME", raising=False)
+        monkeypatch.delenv("DEV_EMAIL", raising=False)
+        monkeypatch.delenv("DEV_TITLE", raising=False)
+
+        runner = CliRunner()
+        result = runner.invoke(main)
+        assert result.exit_code == 0
+        assert "파일" in result.output
+    finally:
+        env_path.unlink(missing_ok=True)


### PR DESCRIPTION
## Summary
- use `python-dotenv` to load profile from `config/.env`
- update README to mention `.env` usage
- add dependency
- test loading from `.env`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rich')*
- `pip install click rich pyfiglet python-dotenv` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6885fc2a14ec83278cbd7655ac3d8a08